### PR TITLE
Fix toggle button reliability issues

### DIFF
--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -32,6 +32,14 @@ interface MainContentProps {
 
 export function MainContent({ user, project }: MainContentProps) {
   const [activeView, setActiveView] = useState<"preview" | "code">("preview");
+  
+  const handleTabChange = useCallback((value: string) => {
+    if (value === "preview" || value === "code") {
+      setActiveView(value);
+    } else {
+      console.warn('Invalid tab value received:', value);
+    }
+  }, []);
 
   return (
     <FileSystemProvider initialData={project?.data}>
@@ -62,9 +70,7 @@ export function MainContent({ user, project }: MainContentProps) {
                 <div className="h-14 border-b border-neutral-200/60 px-6 flex items-center justify-between bg-neutral-50/50">
                   <Tabs
                     value={activeView}
-                    onValueChange={(v) =>
-                      setActiveView(v as "preview" | "code")
-                    }
+                    onValueChange={handleTabChange}
                   >
                     <TabsList className="bg-white/60 border border-neutral-200/60 p-0.5 h-9 shadow-sm">
                       <TabsTrigger value="preview" className="data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm text-neutral-600 px-4 py-1.5 text-sm font-medium transition-all">Preview</TabsTrigger>


### PR DESCRIPTION
Fixes ##2

Improved the reliability of the Preview/Code toggle buttons by:

- Adding proper value validation in onValueChange handler
- Using useCallback to prevent unnecessary re-renders
- Adding warning for invalid tab values
- Improving event handling robustness

Generated with [Claude Code](https://claude.ai/code)